### PR TITLE
docs: rebrand Azure Cosmos DB for MongoDB vCore -> Azure DocumentDB

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,4 +1,4 @@
-metadata description = 'Provisions resources for a web application that uses MongoDB driver for .NET to connect to Azure Cosmos DB for MongoDB vCore.'
+metadata description = 'Provisions resources for a web application that uses MongoDB driver for .NET to connect to Azure DocumentDB (with MongoDB compatibility).'
 
 targetScope = 'resourceGroup'
 
@@ -207,7 +207,7 @@ module containerAppsWebApp 'br/public:avm/res/app/container-app:0.16.0' = {
           }
           {
             name: 'SETTINGS__HEADERSUFFIX'
-            value: 'Azure Cosmos DB for MongoDB vCore - .NET'
+            value: 'Azure DocumentDB - .NET'
           }
         ]
       }

--- a/infra/mongo.bicep
+++ b/infra/mongo.bicep
@@ -1,6 +1,6 @@
-metadata description = 'Provisions resources for an Azure Cosmos DB for MongoDB vCore cluster.'
+metadata description = 'Provisions resources for an Azure DocumentDB (with MongoDB compatibility) cluster.'
 
-@description('The name of the Azure Cosmos DB for MongoDB vCore cluster.')
+@description('The name of the Azure DocumentDB cluster.')
 param name string
 
 @description('Primary location for the resources.')

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # Azure DocumentDB (with MongoDB compatibility) Quickstart - MongoDB driver for .NET
 
-This Quickstart is a ASP.NET minimal API application that illustrates basic usage of the MongoDB driver for .NET with [Azure DocumentDB](https://learn.microsoft.com/azure/cosmos-db/mongodb/vcore). [Azure DocumentDB](https://learn.microsoft.com/azure/cosmos-db/mongodb/vcore/oss) is built on [DocumentDB](https://github.com/documentdb) providing a powerful and flexible solution for NoSQL database needs.
+This Quickstart is a ASP.NET minimal API application that illustrates basic usage of the MongoDB driver for .NET with [Azure DocumentDB](https://learn.microsoft.com/azure/documentdb/). [Azure DocumentDB](https://learn.microsoft.com/azure/documentdb/) is built on [DocumentDB](https://github.com/documentdb) providing a powerful and flexible solution for NoSQL database needs.
 
 ## Pre-requisites
 

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
-# Azure Cosmos DB for MongoDB vCore Quickstart - MongoDB driver for .NET
+# Azure DocumentDB (with MongoDB compatibility) Quickstart - MongoDB driver for .NET
 
-This Quickstart is a ASP.NET minimal API application that illustrates basic usage of the MongoDB driver for .NET with [Azure Cosmos DB for MongoDB vCore](https://learn.microsoft.com/azure/cosmos-db/mongodb/vcore). [Azure Cosmos DB for MongoDB vCore](https://learn.microsoft.com/azure/cosmos-db/mongodb/vcore/oss) is built on [DocumentDB](https://github.com/documentdb) providing a powerful and flexible solution for NoSQL database needs.
+This Quickstart is a ASP.NET minimal API application that illustrates basic usage of the MongoDB driver for .NET with [Azure DocumentDB](https://learn.microsoft.com/azure/cosmos-db/mongodb/vcore). [Azure DocumentDB](https://learn.microsoft.com/azure/cosmos-db/mongodb/vcore/oss) is built on [DocumentDB](https://github.com/documentdb) providing a powerful and flexible solution for NoSQL database needs.
 
 ## Pre-requisites
 
@@ -20,7 +20,7 @@ architecture-beta
 
     service registry(server)[Container registry] in azure
     service identity(disk)[Managed identity] in azure
-    service data(database)[Azure Cosmos DB for MongoDB vCore] in azure
+    service data(database)[Azure DocumentDB] in azure
 
     group host(server)[Azure Container Apps] in azure
 
@@ -63,7 +63,7 @@ architecture-beta
 
 ## (Optional) Run the solution locally
 
-1. If you haven't deployed the solution already, provision the Azure infrastructure to deploy the Azure Cosmos DB for MongoDB vCore account with Microsoft Entra ID authentication enabled.
+1. If you haven't deployed the solution already, provision the Azure infrastructure to deploy the Azure DocumentDB account with Microsoft Entra ID authentication enabled.
 
     ```shell
     azd provision

--- a/src/api/Factories/MongoEntraClientFactory.cs
+++ b/src/api/Factories/MongoEntraClientFactory.cs
@@ -1,12 +1,12 @@
 namespace Microsoft.Learn.AzureCosmosDBMongoDBVCoreQuickstart.Api.Factories;
 
 /// <summary>
-/// Factory for creating MongoDB clients with Microsoft Entra authentication support using the best-practices from Azure Cosmos DB for MongoDB vCore.
+/// Factory for creating MongoDB clients with Microsoft Entra authentication support using the best-practices from Azure DocumentDB (with MongoDB compatibility).
 /// </summary>
 internal sealed class MongoEntraClientFactory
 {
     /// <summary>
-    /// This includes the fixed scope for the Azure Cosmos DB for MongoDB vCore service, which is "https://ossrdbms-aad.database.windows.net/.default".
+    /// This includes the fixed scope for the Azure DocumentDB service, which is "https://ossrdbms-aad.database.windows.net/.default".
     /// </summary>
     private string[] Scopes { get; } = ["https://ossrdbms-aad.database.windows.net/.default"];
 
@@ -14,7 +14,7 @@ internal sealed class MongoEntraClientFactory
     /// Creates a <see cref="IMongoClient"/> client instance with Microsoft Entra authentication support using the provided <see cref="TokenCredential"/>.
     /// </summary>
     /// <param name="endpoint" example="&lt;account-name&gt;.global.mongocluster.cosmos.azure.com">
-    /// The endpoint of the Azure Cosmos DB for MongoDB vCore service. This is tpyically in the format "&lt;account-name&gt;.global.mongocluster.cosmos.azure.com".
+    /// The endpoint of the Azure DocumentDB service. This is tpyically in the format "&lt;account-name&gt;.global.mongocluster.cosmos.azure.com".
     /// </param>
     /// <param name="tenantId">
     /// The Microsoft Entra tenant ID to use for authentication. This is the ID of the Microosft Entra tenant that contains the principal that will be used to authenticate.
@@ -27,8 +27,8 @@ internal sealed class MongoEntraClientFactory
     /// An optional action to configure the <see cref="MongoClientSettings"/> before creating the client. This can be used to set additional options or modify the default settings.
     /// </param>
     /// <remarks>
-    /// The typical credential format for Azure Cosmos DB for MongoDB vCore is "mongodb+srv://&lt;account-name&gt;.global.mongocluster.cosmos.azure.com/?tls=true&amp;authMechanism=MONGODB-OIDC&amp;retrywrites=false&amp;maxIdleTimeMS=120000".
-    /// The <see cref="MongoClientSettings"/> are configured with the recommended settings for Azure Cosmos DB for MongoDB vCore, including TLS, retry writes, and connection idle time from this crdential.
+    /// The typical credential format for Azure DocumentDB is "mongodb+srv://&lt;account-name&gt;.global.mongocluster.cosmos.azure.com/?tls=true&amp;authMechanism=MONGODB-OIDC&amp;retrywrites=false&amp;maxIdleTimeMS=120000".
+    /// The <see cref="MongoClientSettings"/> are configured with the recommended settings for Azure DocumentDB, including TLS, retry writes, and connection idle time from this crdential.
     /// </remarks>
     public IMongoClient CreateMongoClient(
         string endpoint,
@@ -45,7 +45,7 @@ internal sealed class MongoEntraClientFactory
         // Creates a new instance of the MongoClientSettings class using the generated URL.
         MongoClientSettings settings = MongoClientSettings.FromUrl(url);
 
-        // Sets the baseline settings for the MongoDB client as recommended by the Azure Cosmos DB for MongoDB vCore product team.
+        // Sets the baseline settings for the MongoDB client as recommended by the Azure DocumentDB product team.
         settings.UseTls = true;
         settings.RetryWrites = false;
         settings.MaxConnectionIdleTime = TimeSpan.FromMinutes(2);

--- a/src/api/Handlers/AzureIdentityTokenHandler.cs
+++ b/src/api/Handlers/AzureIdentityTokenHandler.cs
@@ -10,7 +10,7 @@ namespace Microsoft.Learn.AzureCosmosDBMongoDBVCoreQuickstart.Api.Handlers;
 /// The Microsoft Entra tenant ID to use for authentication. This is the ID of the Microosft Entra tenant that contains the principal that will be used to authenticate.
 /// </param>
 /// <param name="scopes">
-/// The scopes to request when acquiring the token. This should typically be set to the fixed scope for the Azure Cosmos DB for MongoDB vCore service, which is "https://ossrdbms-aad.database.windows.net/.default".
+/// The scopes to request when acquiring the token. This should typically be set to the fixed scope for the Azure DocumentDB (with MongoDB compatibility) service, which is "https://ossrdbms-aad.database.windows.net/.default".
 /// </param>
 /// <remarks>
 /// This class implements the <see cref="IOidcCallback"/> interface, which is used by the <see cref="MongoDB.Driver"/> to acquire OIDC tokens for authentication.


### PR DESCRIPTION
## Summary

Microsoft has renamed the managed MongoDB-compatible service from **Azure Cosmos DB for MongoDB vCore** to **Azure DocumentDB (with MongoDB compatibility)**. Wire protocol, connection strings, drivers, and APIs are unchanged.

This PR updates user-visible product references in this sample to the new name. No code identifiers, package names, namespaces, or class names were changed; only docs, descriptions, and log messages.

See: https://learn.microsoft.com/azure/documentdb/

## Convention used
- First reference per file: **Azure DocumentDB (with MongoDB compatibility)**
- Subsequent references: **Azure DocumentDB**

## Backward compatibility
No source or binary breakage. Existing class names, package paths, namespaces, and infra resource names are unchanged.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
